### PR TITLE
Creating tarball in upload-S3 action instead of release action.

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -80,10 +80,6 @@ runs:
           rm -rv release/install/install/
         fi
 
-        # Create tarball
-        echo " \n ==> Creating tarball \n"
-        tar -C ./release -czvf release.tar.gz .
-
         # Generate version file
         echo " \n ==> Write version file \n"
         echo $buildNum > latestBuild

--- a/upload-s3/action.yml
+++ b/upload-s3/action.yml
@@ -15,6 +15,7 @@ runs:
   steps:
     - name: Create tarball
       run: tar -C ./release -czvf release.tar.gz .
+      shell: bash
     - name: Upload release
       run: aws s3api put-object --bucket ${{ inputs.bucket }} --key ${{ inputs.product }}/${{ inputs.branch }}/${{ inputs.build }}/release.tar.gz --body release.tar.gz
       shell: bash

--- a/upload-s3/action.yml
+++ b/upload-s3/action.yml
@@ -13,6 +13,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Create tarball
+      run: tar -C ./release -czvf release.tar.gz .
     - name: Upload release
       run: aws s3api put-object --bucket ${{ inputs.bucket }} --key ${{ inputs.product }}/${{ inputs.branch }}/${{ inputs.build }}/release.tar.gz --body release.tar.gz
       shell: bash


### PR DESCRIPTION
This allows us to add one-off file copies (i.e. for jar files)

- [x] make sure this works before merging