### PR TITLE
Adding support for scraping the version number right from the pom file

### DIFF
--- a/java-build/entrypoint.sh
+++ b/java-build/entrypoint.sh
@@ -37,7 +37,19 @@ if [ $deploy = false ]; then
 fi
 
 # deploy to Artifactory
-packageVersion="1.0.$productBuildNumber"
+if [ -z $productBuildNumber ]; then
+  # get the package version from the pom.xml
+  # add following to pom.xml
+  # <plugin>
+  #    <groupId>org.apache.maven.plugins</groupId>
+  #    <artifactId>maven-help-plugin</artifactId>
+  #    <version>3.2.0+</version>
+  # </plugin>
+  packageVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+else
+  packageVersion="1.0.$productBuildNumber"
+fi
+
 if [ ! -z $productBranch ] && [ $productBranch != "master" ]; then
   packageVersion="$packageVersion-$productBranch"
 fi


### PR DESCRIPTION
**PR Summary**

Adding a Java version of the EARP Resolver in the shared libraries repo and wanted the versioning strategy to be similar to the NodeJS: ie manually increment the version before merge to master. 

As I intend to reuse `bdp-ci-action` I need a way to get the version directly from the pom file. 

If a build number is provided then the legacy versioning remains unaffected. 

**Quality Notes**
![image](https://user-images.githubusercontent.com/11636669/120649341-a59bb080-c44a-11eb-8f69-c9bb43c43da6.png)
