### PR TITLE
Avoid releasing multiple dev builds with same version (will fail with immutable check in artifactory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Github actions for BDP CI
 
 ## java-build
 If DEPLOY="true" is set on a component's CI then this script only releases commits to master to Artifactory.
-If a developer needs to publish a development build change the component CI to use DEPLOY="force" on the development branch.
+If a developer needs to publish a development build simply change the component CI to use DEPLOY="force" on the development branch.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # bdp-ci-action
 Github actions for BDP CI
+
+
+## java-build
+If DEPLOY="true" is set on a component's CI then this script only releases commits to master to Artifactory.
+If a developer needs to publish a development build change the component CI to use DEPLOY="force" on the development branch.

--- a/java-build/entrypoint.sh
+++ b/java-build/entrypoint.sh
@@ -50,13 +50,11 @@ else
   packageVersion="1.0.$productBuildNumber"
 fi
 
-if [ ! -z $productBranch ] && [ $productBranch != "master" ]; then
-  packageVersion="$packageVersion-$productBranch"
+# deploy to Artifactory only on master
+if [ ! -z $productBranch ] && [ $productBranch = "master" ]; then
+  echo "deploying version: '$packageVersion'"
+  echo "\n ==> Deploy to Artifactory \n"
+
+  mvn -s ~/.m2/settings.xml -f pom.xml "-DnewVersion=$packageVersion" versions:set
+  mvn -s ~/.m2/settings.xml -f pom.xml install deploy
 fi
-
-echo "deploying version: '$packageVersion'"
-
-echo "\n ==> Deploy to Artifactory \n"
-
-mvn -s ~/.m2/settings.xml -f pom.xml "-DnewVersion=$packageVersion" versions:set
-mvn -s ~/.m2/settings.xml -f pom.xml install deploy

--- a/java-build/entrypoint.sh
+++ b/java-build/entrypoint.sh
@@ -32,7 +32,7 @@ export CI_BUILD_NUMBER=$GITHUB_RUN_ID
 mvn -s ~/.m2/settings.xml verify jacoco:report coveralls:report
 
 # exit script if deploy is false
-if [ $deploy = false ]; then
+if [ $deploy = "false" ]; then
   exit 0
 fi
 
@@ -50,8 +50,8 @@ else
   packageVersion="1.0.$productBuildNumber"
 fi
 
-# deploy to Artifactory only on master
-if [ ! -z $productBranch ] && [ $productBranch = "master" ]; then
+# deploy to Artifactory only on master or if a dev wants to force a dev branch to build
+if ([ ! -z $productBranch ] && [ $productBranch = "master" ]) || [ $deploy = "force" ]; then
   echo "deploying version: '$packageVersion'"
   echo "\n ==> Deploy to Artifactory \n"
 


### PR DESCRIPTION
**PR Summary**

@SEsseltine's change to `bdp-java-utils` will introduce our first component which could attempt to publish multiple dev builds to artifactory with the same version number (assuming the dev does not modify it on each commit which makes sense)

Proposal: Only release on builds to master - which SHOULD have the version bump

Sanity check: I have never used a released dev version of any of our Java libraries but others may have. Interested to hear your preferences. 