### PR TITLE
Adding an option to overload the coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,8 @@ Github actions for BDP CI
 
 
 ## java-build
-If DEPLOY="true" is set on a component's CI then this script only releases commits to master to Artifactory.
+- If DEPLOY="true" is set on a component's CI then this script only releases commits to master to Artifactory.
 If a developer needs to publish a development build simply change the component CI to use DEPLOY="force" on the development branch.
+
+- By default the java-build will assume that both Jacoco and Coveralls are enabled plugins. You can overwrite
+the coverage directives with `CODE_COVERAGE_COMMANDS=<custom commands>`. An empty string disables code coverage.

--- a/java-build/action.yml
+++ b/java-build/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'CI build number'
     required: false
     default: 10000
+  CODE_COVERAGE_COMMANDS:
+    description: 'Additional commands to run for code coverage requirements'
+    required: false
+    default: "jacoco:report coveralls:report"
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -29,3 +33,4 @@ runs:
     - ${{ inputs.DEPLOY }}
     - ${{ inputs.BRANCH }}
     - ${{ inputs.BUILDNUM }}
+    - ${{ inputs.CODE_COVERAGE_COMMANDS }}

--- a/java-build/entrypoint.sh
+++ b/java-build/entrypoint.sh
@@ -30,7 +30,7 @@ cd $projectPath
 export COVERALLS_PARALLEL=true
 export CI_NAME=Github
 export CI_BUILD_NUMBER=$GITHUB_RUN_ID
-mvn -s ~/.m2/settings.xml verify "$codeCoverageCommands"
+mvn -s ~/.m2/settings.xml verify $codeCoverageCommands
 
 # exit script if deploy is false
 if [ $deploy = "false" ]; then

--- a/java-build/entrypoint.sh
+++ b/java-build/entrypoint.sh
@@ -7,6 +7,7 @@ projectPath=$2
 deploy=$3
 productBranch=$4
 productBuildNumber=$5
+codeCoverageCommands=$6
 
 echo " \n\n === Building .jar file === \n"
 
@@ -29,7 +30,7 @@ cd $projectPath
 export COVERALLS_PARALLEL=true
 export CI_NAME=Github
 export CI_BUILD_NUMBER=$GITHUB_RUN_ID
-mvn -s ~/.m2/settings.xml verify jacoco:report coveralls:report
+mvn -s ~/.m2/settings.xml verify "$codeCoverageCommands"
 
 # exit script if deploy is false
 if [ $deploy = "false" ]; then


### PR DESCRIPTION
**PR Summary**
I ran into an issue setting up an empty maven project. No source = no jacoco report = nothing to upload to coveralls. 
Additionally, it makes sense to decouple the action from those two specific libraries. 