### PR TITLE
Allow for components to override location of the installer-features.txt file.

### DIFF
--- a/upload-s3/action.yml
+++ b/upload-s3/action.yml
@@ -11,6 +11,9 @@ inputs:
     required: true
   untar:
     default: false
+  path-to-installer-features:
+    required: false
+    default: installer-features.txt
 
 runs:
   using: "composite"
@@ -34,7 +37,7 @@ runs:
       run: aws s3api put-object --bucket ${{ inputs.bucket }} --key ${{ inputs.product }}/${{ inputs.branch }}/${{ inputs.build }}/release.tar.gz --body release.tar.gz
       shell: bash
     - name: Upload installer features
-      run: aws s3api put-object --bucket ${{ inputs.bucket }} --key ${{ inputs.product }}/${{ inputs.branch }}/${{ inputs.build }}/install/installer-features.txt --body installer-features.txt
+      run: aws s3api put-object --bucket ${{ inputs.bucket }} --key ${{ inputs.product }}/${{ inputs.branch }}/${{ inputs.build }}/install/installer-features.txt --body ${{ inputs.path-to-installer-features }}
       shell: bash
     - name: Update latest build
       run: aws s3api put-object --bucket ${{ inputs.bucket }} --key ${{ inputs.product }}/${{ inputs.branch }}/latestBuild --body latestBuild


### PR DESCRIPTION
**PR Summary**
99% of BDP and BEF components place the `installer-features.txt` file at the repo root. However, the BEF system tests do not as they have a more nested structure. 
The upload to S3 directive was failing due to the inability to find the file at the root
```
Run aws s3api put-object --bucket d2l-adp-west --key bef-system-tests/UpgradeNode14/10011/install/installer-features.txt --body installer-features.txt

Error parsing parameter '--body': Blob values must be a path to a file.
```
Extending this build step to allow for an optional override. 

**Testing**
Testing this component isn't easy - what I will do is that after merge I will rebuild both bef-system-tests and another component without the override to verify success. If there are failures I will fix/revert