### PR TITLE
Filtering out unit tests and documentation from release package

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -54,6 +54,8 @@ runs:
           egrep -v '^bdp-ci' |
           egrep -v '^spark/' |
           egrep -v '^handlers/' |
+          egrep -v '^docs/' |
+          egrep -v '^test/' |
           xargs -I{} cp --parents -Rv {} release/install/
 
         # Take care of serverless plugins

--- a/release/action.yml
+++ b/release/action.yml
@@ -1,5 +1,10 @@
 name: 'Stage Release'
 description: 'Create release package for BDP'
+inputs:
+  test_directory_exclude:
+    description: 'The test directory to exclude'
+    required: false
+    default: 'test'
 outputs:
   branch:
     description: Git branch
@@ -55,7 +60,7 @@ runs:
           egrep -v '^spark/' |
           egrep -v '^handlers/' |
           egrep -v '^docs/' |
-          egrep -v '^test/' |
+          egrep -v '^${{ inputs.test_directory_exclude }}/' |
           xargs -I{} cp --parents -Rv {} release/install/
 
         # Take care of serverless plugins


### PR DESCRIPTION
**PR Summary**
Adjusting default package GitHub action such that it stops bundling unit tests and documentation. This will shrink the size of our component packages. 

What's next:
bdp2-system-tests and bef-system-tests have atypical names for their test folders. After this is merged I will add the appropriate exclusion override to their CI script. 

**Quality Notes**
I plan to merge and then build a dev branch of bdp-batch to verify CI success. Will immediately rollback if there are any issues. 