### PR TITLE
Ensuring that the compile event schema is persisted for packaging/upload to S3

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -33,7 +33,7 @@ runs:
         fi
 
         echo " \n ==> Clean Existing Folders \n"
-        git clean -fxd -e mocha.xml -e coverage/ -e spark/ -e *.jar
+        git clean -fxd -e mocha.xml -e coverage/ -e spark/ -e *.jar -e events/
 
         echo " \n ==> Creating Git Revision File \n"
         mkdir -p release/


### PR DESCRIPTION
**PR Summary**
The Schema repo resolves the raw event schema into a new folder 'events/'. To pivot CI to github actions ensuring that this folder isn't removed. 

The screen capture is what is currently happening during my dev builds - ie. the events folder after it is built it is not being packaged accurately. 
![image](https://user-images.githubusercontent.com/11636669/149346263-dcc69a70-b9e2-45c6-9e48-4418d8f666a1.png)
