### PR TITLE
Bypassing the pruning wasn't enough. Explicitly packaging the resolved events directory

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -82,6 +82,13 @@ runs:
           mv -v release/install/configs release/
         fi
 
+        # Take care of schema
+        if [ -d "events" ]; then
+          echo " \n ==> Stage Schema \n"
+          mkdir -p release/install/events
+          cp -vR events/* release/install/events
+        fi
+
         if [ -d "install" ]; then
           mv -v release/install/install/* release/install/
           sudo rm -rv release/install/install/


### PR DESCRIPTION
**PR Summary**
The script uses `git ls-files` which only reports on files added to source control. So any transient folders/files aren't included. 
Now that we don't clean up the `events/` folder we need to explicitly package it. 

Aside: I decided to be explicit rather than implement some sort of generic solution only because I think that the schema repo is really the only one (other than those with spark applications) which builds transient files. 