### PR TITLE
feat(EAP-1853): GHA run directive

### DIFF
--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -51,7 +51,6 @@ runs:
         DIRECTIVES: ${{ inputs.directives }}
         STAGE: ${{ inputs.stage }}
       run: |
-        npm ci
-        for d in ${ DIRECTIVES }; do
-          npm run ${ d } -- --stage ${ STAGE }
+        for d in ${{ env.DIRECTIVES }}; do
+          echo npm run ${ d } -- --stage ${{ env.STAGE }}
         done

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -25,9 +25,6 @@ jobs:
     using: "composite"
 
     steps:
-      - name: Setup Environment
-        uses: Brightspace/bdp-ci-action/setup-env@master
-
       - name: Checkout branch with hash
         uses: Brightspace/third-party-actions@actions/checkout
         if: ${{ inputs.hash == '' }}

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -48,12 +48,10 @@ jobs:
         with:
           auth-token: ${{secrets.CODEARTIFACT_AUTH_TOKEN}}
 
-      - name: Setup working directory
-        run: |
-          cp ${{ inputs.config }} ${{ inputs.working-directory }}/config.json
-          cd ${{ inputs.working-directory }}
-          npm ci
-
       - name: Run directive
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          CONFIG_PATH: ${{ inputs.config }}
         run: |
+          npm ci
           npm run ${{ inputs.directive }} -- --stage ${{ inputs.stage }}

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -48,8 +48,9 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         CONFIG_PATH: ${{ inputs.config }}
+        DIRECTIVES: ${{ inputs.directives }}
       run: |
         npm ci
-        for d in ${{ input.directives }}; do
+        for d in ${ DIRECTIVES }; do
           npm run ${ d } -- --stage ${{ inputs.stage }}
         done

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -22,17 +22,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout branch with hash
+    - name: Checkout branch
       uses: Brightspace/third-party-actions@actions/checkout
-      if: ${{ inputs.hash != '' }}
       with:
         ref: ${{ inputs.hash }}
-        fetch-depth: 0
-
-    - name: Checkout branch without hash
-      uses: Brightspace/third-party-actions@actions/checkout
-      if: ${{ inputs.hash == '' }}
-      with:
         fetch-depth: 0
 
     - name: Use Node.js

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -19,41 +19,38 @@ inputs:
     description: 'Directives to run. Multiple directives separated by spaces e.g. test deploy'
     required: true
 
-jobs:
-  npm-directive:
-    name: Run NPM Directive
-    using: "composite"
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout branch with hash
+      uses: Brightspace/third-party-actions@actions/checkout
+      if: ${{ inputs.hash == '' }}
+      with:
+        fetch-depth: 0
 
-    steps:
-      - name: Checkout branch with hash
-        uses: Brightspace/third-party-actions@actions/checkout
-        if: ${{ inputs.hash == '' }}
-        with:
-          fetch-depth: 0
+    - name: Checkout branch with hash
+      uses: Brightspace/third-party-actions@actions/checkout
+      if: ${{ inputs.hash != '' }}
+      with:
+        ref: ${{ inputs.hash }}
+        fetch-depth: 0
 
-      - name: Checkout branch with hash
-        uses: Brightspace/third-party-actions@actions/checkout
-        if: ${{ inputs.hash != '' }}
-        with:
-          ref: ${{ inputs.hash }}
-          fetch-depth: 0
+    - name: Use Node.js
+      uses: Brightspace/third-party-actions@actions/setup-node
+      with:
+        node-version-file: .nvmrc
 
-      - name: Use Node.js
-        uses: Brightspace/third-party-actions@actions/setup-node
-        with:
-          node-version-file: .nvmrc
+    - name: Add CodeArtifact npm registry
+      uses: Brightspace/codeartifact-actions/npm/add-registry@main
+      with:
+        auth-token: ${{secrets.CODEARTIFACT_AUTH_TOKEN}}
 
-      - name: Add CodeArtifact npm registry
-        uses: Brightspace/codeartifact-actions/npm/add-registry@main
-        with:
-          auth-token: ${{secrets.CODEARTIFACT_AUTH_TOKEN}}
-
-      - name: Run directives
-        working-directory: ${{ inputs.working-directory }}
-        env:
-          CONFIG_PATH: ${{ inputs.config }}
-        run: |
-          npm ci
-          for d in ${{ input.directives }}; do
-            npm run ${{ d }} -- --stage ${{ inputs.stage }}
-          done
+    - name: Run directives
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        CONFIG_PATH: ${{ inputs.config }}
+      run: |
+        npm ci
+        for d in ${{ input.directives }}; do
+          npm run ${{ d }} -- --stage ${{ inputs.stage }}
+        done

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -24,8 +24,9 @@ runs:
   steps:
     - name: Checkout branch with hash
       uses: Brightspace/third-party-actions@actions/checkout
-      if: ${{ inputs.hash == '' }}
+      if: ${{ inputs.hash != '' }}
       with:
+        ref: ${{ inputs.hash }}
         fetch-depth: 0
 
     - name: Checkout branch without hash

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -49,8 +49,9 @@ runs:
       env:
         CONFIG_PATH: ${{ inputs.config }}
         DIRECTIVES: ${{ inputs.directives }}
+        STAGE: ${{ inputs.stage }}
       run: |
         npm ci
         for d in ${ DIRECTIVES }; do
-          npm run ${ d } -- --stage ${{ inputs.stage }}
+          npm run ${ d } -- --stage ${ STAGE }
         done

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -15,8 +15,8 @@ inputs:
   stage:
     description: 'Name of stage'
     required: true
-  directives:
-    description: 'Directives to run. Multiple directives separated by spaces e.g. test deploy'
+  directive:
+    description: 'Directive to run. e.g. test, deploy'
     required: true
 
 runs:
@@ -44,13 +44,11 @@ runs:
       with:
         auth-token: ${{secrets.CODEARTIFACT_AUTH_TOKEN}}
 
-    - name: Run directives
+    - name: Run directive
       working-directory: ${{ inputs.working-directory }}
       env:
         CONFIG_PATH: ${{ inputs.config }}
-        DIRECTIVES: ${{ inputs.directives }}
+        DIRECTIVE: ${{ inputs.directive }}
         STAGE: ${{ inputs.stage }}
       run: |
-        for d in ${{ env.DIRECTIVES }}; do
-          npm run ${ d } -- --stage ${{ env.STAGE }}
-        done
+        npm run ${{ env.DIRECTIVE }} -- --stage ${{ env.STAGE }}

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -52,5 +52,5 @@ runs:
         STAGE: ${{ inputs.stage }}
       run: |
         for d in ${{ env.DIRECTIVES }}; do
-          echo npm run ${ d } -- --stage ${{ env.STAGE }}
+          npm run ${ d } -- --stage ${{ env.STAGE }}
         done

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -1,4 +1,4 @@
-name: Run Directive
+name: Run NPM Directive
 run-name: test
 
 inputs:
@@ -16,20 +16,27 @@ inputs:
     description: 'Name of stage'
     required: true
   directive:
-    description: 'A directive to run. e.g. npm ci, npm run test'
+    description: 'A directive to run. e.g. test, deploy, teardown'
     required: true
 
 jobs:
-  run-directive:
-    name: Run Directive
+  npm-directive:
+    name: Run NPM Directive
     using: "composite"
 
     steps:
       - name: Setup Environment
         uses: Brightspace/bdp-ci-action/setup-env@master
 
-      - name: Checkout branch
+      - name: Checkout branch with hash
         uses: Brightspace/third-party-actions@actions/checkout
+        if: ${{ inputs.hash == '' }}
+        with:
+          fetch-depth: 0
+
+      - name: Checkout branch with hash
+        uses: Brightspace/third-party-actions@actions/checkout
+        if: ${{ inputs.hash != '' }}
         with:
           ref: ${{ inputs.hash }}
           fetch-depth: 0
@@ -48,7 +55,8 @@ jobs:
         run: |
           cp ${{ inputs.config }} ${{ inputs.working-directory }}/config.json
           cd ${{ inputs.working-directory }}
+          npm ci
 
       - name: Run directive
         run: |
-          ${{ inputs.directive }} -- --stage ${{ inputs.stage }}
+          npm run ${{ inputs.directive }} -- --stage ${{ inputs.stage }}

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -52,5 +52,5 @@ runs:
       run: |
         npm ci
         for d in ${{ input.directives }}; do
-          npm run ${{ d }} -- --stage ${{ inputs.stage }}
+          npm run ${ d } -- --stage ${{ inputs.stage }}
         done

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -45,4 +45,4 @@ runs:
         DIRECTIVE: ${{ inputs.directive }}
         STAGE: ${{ inputs.stage }}
       run: |
-        npm run ${{ env.DIRECTIVE }} -- --stage ${{ env.STAGE }}
+        npm run ${ DIRECTIVE } -- --stage ${ STAGE }

--- a/npm-directive/action.yml
+++ b/npm-directive/action.yml
@@ -15,8 +15,8 @@ inputs:
   stage:
     description: 'Name of stage'
     required: true
-  directive:
-    description: 'A directive to run. e.g. test, deploy, teardown'
+  directives:
+    description: 'Directives to run. Multiple directives separated by spaces e.g. test deploy'
     required: true
 
 jobs:
@@ -48,10 +48,12 @@ jobs:
         with:
           auth-token: ${{secrets.CODEARTIFACT_AUTH_TOKEN}}
 
-      - name: Run directive
+      - name: Run directives
         working-directory: ${{ inputs.working-directory }}
         env:
           CONFIG_PATH: ${{ inputs.config }}
         run: |
           npm ci
-          npm run ${{ inputs.directive }} -- --stage ${{ inputs.stage }}
+          for d in ${{ input.directives }}; do
+            npm run ${{ d }} -- --stage ${{ inputs.stage }}
+          done

--- a/run-directive/action.yml
+++ b/run-directive/action.yml
@@ -1,0 +1,58 @@
+name: Run Directive
+run-name: test
+
+inputs:
+  repository:
+    description: 'Github repo'
+    required: true
+  hash:
+    description: 'Github commit hash to checkout'
+    required: false
+    default: ''
+  working-directory:
+    description: 'Name of component directory'
+    required: true
+  config:
+    description: 'Config JSON file'
+    required: true
+  stage:
+    description: 'Name of stage'
+    required: true
+  directive:
+    description: 'An npm directive. e.g. deploy, test'
+    required: true
+
+jobs:
+  run-directive:
+    name: Run Directive
+    using: "composite"
+
+    steps:
+      - name: Setup Environment
+        uses: Brightspace/bdp-ci-action/setup-env@master
+
+      - name: Checkout branch
+        uses: Brightspace/third-party-actions@actions/checkout
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.hash }}
+          fetch-depth: 0
+
+      - name: Use Node.js
+        uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version-file: .nvmrc
+
+      - name: Add CodeArtifact npm registry
+        uses: Brightspace/codeartifact-actions/npm/add-registry@main
+        with:
+          auth-token: ${{secrets.CODEARTIFACT_AUTH_TOKEN}}
+
+      - name: Setup working directory
+        run: |
+          cp ${{ inputs.config }} ${{ inputs.working-directory }}/config.json
+          cd ${{ inputs.working-directory }}
+
+      - name: Run directive
+        run: |
+          npm run ${{ inputs.directive }} -- --stage ${{ inputs.stage }}

--- a/run-directive/action.yml
+++ b/run-directive/action.yml
@@ -2,9 +2,6 @@ name: Run Directive
 run-name: test
 
 inputs:
-  repository:
-    description: 'Github repo'
-    required: true
   hash:
     description: 'Github commit hash to checkout'
     required: false
@@ -34,7 +31,6 @@ jobs:
       - name: Checkout branch
         uses: Brightspace/third-party-actions@actions/checkout
         with:
-          repository: ${{ inputs.repository }}
           ref: ${{ inputs.hash }}
           fetch-depth: 0
 

--- a/run-directive/action.yml
+++ b/run-directive/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: 'Name of stage'
     required: true
   directive:
-    description: 'An npm directive. e.g. deploy, test'
+    description: 'A directive to run. e.g. npm ci, npm run test'
     required: true
 
 jobs:

--- a/run-directive/action.yml
+++ b/run-directive/action.yml
@@ -55,4 +55,4 @@ jobs:
 
       - name: Run directive
         run: |
-          npm run ${{ inputs.directive }} -- --stage ${{ inputs.stage }}
+          ${{ inputs.directive }} -- --stage ${{ inputs.stage }}


### PR DESCRIPTION
[EAP-1853](https://desire2learn.atlassian.net/browse/EAP-1853)

Adding a github action to run a directive for a given github repo.

[EAP-1853]: https://desire2learn.atlassian.net/browse/EAP-1853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Quality Notes

Testing locally in VSCode using [ACT](https://nektosact.com/introduction.html) and [VSCode Github Actions Plugin](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions).

Since ACT seems to hate github actions, I used an approximately equivalent workflow (below) and the output file is attached. Things to note:
- removed setting up code artifact or calling npm ci: I didn't want to spend time figuring this out when these are shared actions
- npm run command failed with test directive but run action: since we're not running npm ci, testing fails, but it is calling the action
- explicitly checkout brightspace-data-platform: we need to check out something

This seems good enough to know the code is syntactically correct and will run if called from a workflow without spending excessive time attempting to test it locally.

```
name: testing

on:
  workflow_dispatch:
    inputs:
      hash:
        description: 'Github commit hash to checkout'
        required: false
        default: ''
      working-directory:
        description: 'Name of component directory'
        required: true
      config:
        description: 'Config JSON file'
        required: true
      stage:
        description: 'Name of stage'
        required: true
      directive:
        description: 'Directives to run. Multiple directives separated by spaces e.g. test deploy'
        required: true

jobs:
  test-job:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout branch
        uses: Brightspace/third-party-actions@actions/checkout
        with:
          ref: ${{ inputs.hash }}
          repository: Brightspace/brightspace-data-platform
          fetch-depth: 0

      - name: Use Node.js
        uses: Brightspace/third-party-actions@actions/setup-node
        with:
          node-version-file: .nvmrc

      - name: Run directives
        working-directory: ${{ inputs.working-directory }}
        env:
          CONFIG_PATH: ${{ inputs.config }}
          DIRECTIVE: ${{ inputs.directive }}
          STAGE: ${{ inputs.stage }}
        run: |
          npm run ${{ env.DIRECTIVE }} -- --stage ${{ env.STAGE }}
```

[act-output.txt](https://github.com/user-attachments/files/20417257/act-output.txt)
