### PR TITLE
feat(EAP-1993): A reusable action to download and extract components from S3

### DIFF
--- a/download-s3/action.yml
+++ b/download-s3/action.yml
@@ -1,0 +1,36 @@
+name: Download S3
+description: Download latest branch package from S3
+inputs:
+  component:
+    required: true
+    description: The desired component to download
+  branch:
+    required: false
+    description: The desired branch of the named component
+    default: master
+  targetFolder:
+    required: true
+    description: The top level folder in which to download
+runs:
+  using: "composite"
+  steps:
+    - name: Download latest component build on branch
+      shell: bash
+      env:
+        COMPONENT: ${{ inputs.component }}
+        BRANCH: ${{ inputs.branch }}
+        FOLDER: ${{ inputs.targetFolder }}
+      run: |
+        
+        # Get the latest build number
+        aws s3api get-object --bucket d2l-adp-west --key $COMPONENT/$BRANCH/latestBuild latestBuilld.txt
+        BUILD_NUMBER=$(cat latestBuilld.txt)
+        
+        # Download the archive
+        aws s3api get-object --bucket d2l-adp-west --key $COMPONENT/$BRANCH/$BUILD_NUMBER/release.tar.gz release.tar.gz
+        
+        # Extract into the desired folder and remove the top level 'install' directory
+        mkdir $FOLDER
+        tar -xvzf release.tar.gz -C $FOLDER
+        mv $FOLDER/install/* $FOLDER
+        rm -r $FOLDER/install


### PR DESCRIPTION
## PR Summary
In order for the BDP to install Infrastructure and BEF components as part of Permapound - the proposed path is that the latest master versions of these components are installed as pseudo-BDP monorepo components. 


## Quality Notes
* Created a test workflow which is basically the action
![image](https://github.com/user-attachments/assets/3eda77ee-f90f-4a9f-a6e5-61007495bf17)

* Verified folder structure
![image](https://github.com/user-attachments/assets/5a2b9e10-2414-40b3-b657-338a9e904ae9)


Note: All the BEF components can be sent to the same top level folder (its okay if the package.json is overwritten as they should all be copies of the same root BEF monorepo file)