### PR TITLE
fix(EAP-1993): Smother error output if there are no hidden files/directories

### DIFF
--- a/download-s3/action.yml
+++ b/download-s3/action.yml
@@ -36,6 +36,6 @@ runs:
           # Extract into the desired folder and remove the top level 'install' directory
           tar -xvzf release.tar.gz -C $FOLDER
           mv $FOLDER/install/* $FOLDER
-          mv $FOLDER/install/.* $FOLDER
+          mv $FOLDER/install/.* $FOLDER 2>/dev/null
           rm -r $FOLDER/install
         done

--- a/download-s3/action.yml
+++ b/download-s3/action.yml
@@ -36,6 +36,6 @@ runs:
           # Extract into the desired folder and remove the top level 'install' directory
           tar -xvzf release.tar.gz -C $FOLDER
           mv $FOLDER/install/* $FOLDER
-          mv $FOLDER/install/.* $FOLDER 2>/dev/null
+          mv $FOLDER/install/.* $FOLDER || true
           rm -r $FOLDER/install
         done


### PR DESCRIPTION
## PR Summary

Found during testing - this was successful for bdp-infrastructure (has .serverless_plugins) but would fail for a component without any hidden folders

Proposal: 
* Throw error if original move unsuccessful - may signal an empty component package
* Smother error if hidden folders move is unsuccessful 

## Quality Notes
Tested locally in Bash shell against archive retrieved by workflow